### PR TITLE
fix(ci): wrap respec build under chrome AppArmor profile

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@
 name: Deploy static content to Pages
 
 on:
+  push:
+    branches: [main]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,8 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
+      - name: Install apparmor-utils
+        run: sudo apt-get update && sudo apt-get install -y apparmor-utils
       - name: Build static spec
         run: node scripts/build.mjs
       - name: Setup Pages

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -52,10 +52,10 @@ log('rendering valos-spec.html via respec CLI');
 let aaExec = '';
 if (process.platform === 'linux') {
   try {
-    execSync('command -v aa-exec', { stdio: 'ignore', shell: '/bin/sh' });
+    execSync('aa-exec --profile=chrome true', { stdio: 'ignore', shell: '/bin/sh' });
     aaExec = 'aa-exec --profile=chrome ';
   } catch {
-    log('aa-exec not found; running respec without AppArmor profile wrapper (Chrome sandbox may fail on Ubuntu 24+)');
+    log('aa-exec or `chrome` AppArmor profile unavailable; running respec without wrapper (Chrome sandbox may fail on Ubuntu 24+)');
   }
 }
 execSync(

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -44,8 +44,22 @@ mkdirSync(DIST, { recursive: true });
 // 2. Render with ReSpec CLI. --localhost spins up a local HTTP server so the
 //    source's relative paths (e.g. ./node_modules/respec/...) resolve.
 log('rendering valos-spec.html via respec CLI');
+// On Linux (incl. GitHub Actions ubuntu-latest), Ubuntu 24+ AppArmor blocks
+// the unprivileged user namespace that Puppeteer's bundled Chromium needs to
+// build its sandbox. We wrap respec under the system's existing `chrome`
+// AppArmor profile (installed by the preinstalled google-chrome-stable
+// package), which permits user namespaces — keeping Chrome's sandbox intact.
+let aaExec = '';
+if (process.platform === 'linux') {
+  try {
+    execSync('command -v aa-exec', { stdio: 'ignore', shell: '/bin/sh' });
+    aaExec = 'aa-exec --profile=chrome ';
+  } catch {
+    log('aa-exec not found; running respec without AppArmor profile wrapper (Chrome sandbox may fail on Ubuntu 24+)');
+  }
+}
 execSync(
-  'npx respec --src=valos-spec.html --out=dist/valos-spec.html --localhost --haltonerror',
+  `${aaExec}npx respec --src=valos-spec.html --out=dist/valos-spec.html --localhost --haltonerror`,
   { stdio: 'inherit' },
 );
 


### PR DESCRIPTION
## Summary

Two CI changes:

1. **Fix the deploy workflow** — currently failing on `ubuntu-latest` (now Ubuntu 24) with `No usable sandbox!` because Puppeteer's bundled Chromium can't build its sandbox without unprivileged user namespaces, which Ubuntu 24+ AppArmor blocks.
2. **Auto-deploy on push to main** — drop the manual `workflow_dispatch` requirement.

## Fix for the sandbox failure

Wrap the ReSpec CLI invocation under the system's existing `chrome` AppArmor profile via `aa-exec`. That profile (registered by the preinstalled `google-chrome-stable` package on ubuntu-latest) permits user namespaces, so the sandbox starts normally.

- [scripts/build.mjs](scripts/build.mjs): on Linux, check for `aa-exec` and prepend `aa-exec --profile=chrome` to the respec command. Falls back with a warning if the binary is missing, so non-CI Linux setups still build.
- [.github/workflows/deploy.yml](.github/workflows/deploy.yml): `apt-get install apparmor-utils` to guarantee `aa-exec` is present on the runner.

## Auto-deploy

[.github/workflows/deploy.yml](.github/workflows/deploy.yml): add `push: branches: [main]` trigger alongside `workflow_dispatch`.