### PR TITLE
fix(spec): typos and minor grammar in valos-spec.html

### DIFF
--- a/valos-spec.html
+++ b/valos-spec.html
@@ -313,7 +313,7 @@ or to more direct financial penalties.
 <tr id="risk-dow-4">
   <td>DOW4</td>
   <td>Infrastructure</td>
-  <td>External: Operational Failure of own bare metal set-up due to people (ManMade)</td>
+  <td>External: Operational Failure of own bare metal set-up due to people (man-made)</td>
   <td>Employees are responsible for the downtime event (accidentally or intentionally)</td>
   <td><ul class="autofill-mits"></ul></td>
 </tr>
@@ -321,7 +321,7 @@ or to more direct financial penalties.
   <td>DOW5</td>
   <td>Infrastructure</td>
   <td>External: Operational Failure of own bare metal set-up due to natural causes</td>
-  <td>A natural event (e.g. earthquake, flood, hurricane,...) leads to an downtime</td>
+  <td>A natural event (e.g. earthquake, flood, hurricane,...) leads to downtime</td>
   <td><ul class="autofill-mits"></ul></td>
 </tr>
 <tr id="risk-dow-6">
@@ -353,7 +353,7 @@ or to more direct financial penalties.
   <td>DOW10</td>
   <td>Infrastructure</td>
   <td>External: DDOS attack</td>
-  <td>Systems unresponsive, slowed down, and compromized</td>
+  <td>Systems unresponsive, slowed down, and compromised</td>
   <td><ul class="autofill-mits"></ul></td>
 </tr>
 <tr id="risk-dow-11">
@@ -407,7 +407,7 @@ or to more direct financial penalties.
   <td>DOW19</td>
   <td>Software</td>
   <td>Running outdated validator software</td>
-  <td>The node operator os not updating its validator software</td>
+  <td>The node operator is not updating its validator software</td>
   <td><ul class="autofill-mits"></ul></td>
 </tr>
 <tr id="risk-dow-20">
@@ -527,7 +527,7 @@ or facilitated by a current or former member of the operational team.
   <td>HCK2 (replaces SLS9, DOW16, KEC2, KEC3, KEC10, GIR2)</td>
   <td>People</td>
   <td>Malicious Internal Employee intentionally causes operational failure via privilege escalation</td>
-  <td>A malicious internal employee can get additional rights via through privileges escalation.</td>
+  <td>A malicious internal employee can get additional rights via privilege escalation.</td>
   <td><ul class="autofill-mits"></ul></td>
 </tr>
 <tr id="risk-hck-3">
@@ -1077,7 +1077,7 @@ ideally providing real protection against a vulnerability present in a single ve
 Note that there are often a different range of clients available at different levels of the infrastructure.
 For example in Ethereum, it is possible to run different clients on each of the Execution and Consensus layers.
 
-##### Best practice fo client diversity includes
+##### Best practice for client diversity includes
 
 - Running multiple Execution and Consensus clients. See also [[[?ETHdiverse]]] [[?ETHdiverse]]
 
@@ -1718,7 +1718,7 @@ This minimizes a potential blast radius. It is important to run any change (even
 
 #### Containerized and Orchestrated Environments {#sec-mit-containerized-environments}
 
-Containerized and orchestrated environments are designed to reinforce security by automating many good practices, with mechanisms that have been widely tested in diverse environments. As tools that can be used well or badly, their best practice recommendations are important to ensure the the full benefits are realised.
+Containerized and orchestrated environments are designed to reinforce security by automating many good practices, with mechanisms that have been widely tested in diverse environments. As tools that can be used well or badly, their best practice recommendations are important to ensure the full benefits are realised.
 
 <div class="info">
 


### PR DESCRIPTION
Seven copy-edit fixes — typos and grammar in risk descriptions and one heading. No semantic or structural changes.

- "ManMade" → "man-made"
- "leads to an downtime" → "leads to downtime"
- "compromized" → "compromised"
- "os not updating" → "is not updating"
- "via through privileges escalation" → "via privilege escalation"
- "fo client diversity" → "for client diversity"
- "the the full benefits" → "the full benefits"