### PR TITLE
fix(webflow): normalize CRLF before hashing inline scripts for CSP

### DIFF
--- a/scripts/process-webflow.mjs
+++ b/scripts/process-webflow.mjs
@@ -49,7 +49,11 @@ function hashInlineScripts(html) {
     if (/\bsrc\s*=/.test(attrs)) continue;
     if (/type\s*=\s*["']application\/(ld\+)?json["']/.test(attrs)) continue;
     if (body.trim() === '') continue;
-    const digest = createHash('sha256').update(body, 'utf8').digest('base64');
+    // HTML5 parsers normalize CRLF -> LF before computing the script
+    // element's text content, which is what CSP hashes. Match that so
+    // hashes from a CRLF source still validate at runtime.
+    const normalized = body.replace(/\r\n/g, '\n');
+    const digest = createHash('sha256').update(normalized, 'utf8').digest('base64');
     hashes.push(`'sha256-${digest}'`);
   }
   return hashes;


### PR DESCRIPTION
## Problem

The expandable sections on the Webflow landing page (For Node Operators / For Auditors / For Stakers) do not open in production. Browser console:

> Executing inline script violates the following Content Security Policy directive 'script-src 'self' 'sha256-…' 'sha256-…''.

## Cause

`Webflow/index.html` ships with CRLF line endings (Windows export). The build-time hash in `scripts/process-webflow.mjs` is computed over the raw CRLF bytes, but HTML5 parsers normalize CRLF to LF before exposing a script element's text content — which is what the browser hashes for CSP enforcement. The multiline dropdown handler at the bottom of the page therefore fails the integrity check.

## Fix

Normalize CRLF to LF in the script body before computing the digest, matching what the browser computes at runtime.