### PR TITLE
fix(webflow): normalize button labels and copy casing

### DIFF
--- a/Webflow/index.html
+++ b/Webflow/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!--  This site was created in Webflow. https://webflow.com  --><!--  Last Published: Wed Feb 25 2026 14:15:50 GMT+0000 (Coordinated Universal Time)  -->
+<!DOCTYPE html><!--  This site was created in Webflow. https://webflow.com  --><!--  Last Published: Fri May 22 2026 17:19:14 GMT+0000 (Coordinated Universal Time)  -->
 <html data-wf-page="6941470cf6e7d13a7d7d7ceb" data-wf-site="6941470cf6e7d13a7d7d7ced">
 <head>
   <meta charset="utf-8">
@@ -151,7 +151,7 @@
         <div class="text-dm-mono-black">Supported by the Lido Labs Foundation</div>
       </div>
       <div class="cell-2">
-        <a href="https://lidofinance.github.io/valos/valos-spec.html" target="_blank" class="button text-dm-mono-black text-white bg-orange width-50 w-button">Get the STANDARD →</a>
+        <a href="https://lidofinance.github.io/valos/valos-spec.html" target="_blank" class="button text-dm-mono-black text-white bg-orange width-50 w-button">Get the Standard →</a>
         <a href="https://t.me/valoscommunity" target="_blank" class="button text-dm-mono-black width-50 w-button">Join the Community →</a>
       </div>
       <div class="cell-3 p-100">
@@ -183,7 +183,7 @@
         </div>
       </div>
       <div id="w-node-_38b793d2-d3b8-da59-a5e0-b746963b97dd-7d7d7ceb" class="cell-6">
-        <div class="text-block-2 color-black text-align-center">Together, this collective ensures that ValOS is not just a theoretical standard but an industry-DRIVEN benchmark for secure and resilient validator operations.</div>
+        <div class="text-block-2 color-black text-align-center">Together, this collective ensures that ValOS is not just a theoretical standard but an industry-driven benchmark for secure and resilient validator operations.</div>
       </div>
       <div id="w-node-c58bc0a1-7302-ea7d-c52b-abbacc065696-7d7d7ceb" class="cell-7">
         <h1 class="heading3">Why ValOS?</h1>
@@ -227,7 +227,7 @@
         </div>
       </div>
       <div id="w-node-ae5dffa6-386c-4832-edf1-df96e2d402f0-7d7d7ceb" class="cell-11">
-        <a href="https://lidofinance.github.io/valos/valos-spec.html" target="_blank" class="button bg-orange text-dm-mono-black text-white w-button">Safer Validation starts here →</a>
+        <a href="https://lidofinance.github.io/valos/valos-spec.html" target="_blank" class="button bg-orange text-dm-mono-black text-white w-button">Safer validation starts here →</a>
       </div>
       <div id="w-node-dfbb01d7-a210-7b08-6709-f50d3cea4ab0-7d7d7ceb" class="cell-15">
         <div id="GETSTARTED" class="text-block-2 badge">[Get Started]</div>
@@ -246,12 +246,12 @@
                 <div class="div-block-4 width-100">
                   <h4 class="text-block bold line-height-30">Improve</h4>
                   <div class="text-block line-height-30 fs-18">Implement process and control improvements to increase the security, redundancy, operational effectiveness, and risk mitigation aspects of your validator infrastructure operations.</div>
-                  <a href="https://lidofinance.github.io/valos/valos-spec.html" target="_blank" class="button text-dm-mono-black button-sm mt-10 w-button">SPecIFICATIONS</a>
+                  <a href="https://lidofinance.github.io/valos/valos-spec.html" target="_blank" class="button text-dm-mono-black button-sm mt-10 w-button">Specifications</a>
                 </div>
                 <div class="div-block-4 width-100">
                   <h4 class="text-block bold line-height-30">Contribute</h4>
                   <div class="text-block line-height-30 fs-18">Help to evolve ValOS by bringing your hands-on expertise through open-source contribution shaping the standard that reflect real-world validator operations.</div>
-                  <a href="https://github.com/lidofinance/valos" target="_blank" class="button text-dm-mono-black button-sm mt-10 w-button">github</a>
+                  <a href="https://github.com/lidofinance/valos" target="_blank" class="button text-dm-mono-black button-sm mt-10 w-button">GitHub</a>
                 </div>
                 <div class="div-block-4 width-100">
                   <h4 class="text-block bold line-height-30">Get Certified</h4>
@@ -277,7 +277,7 @@
                 <div class="div-block-4 width-100">
                   <h4 class="text-block bold line-height-30"><strong>Understand The Standard</strong></h4>
                   <div class="text-block line-height-30 fs-18">Understand how ValOS aligns with industry standards such as SOC 2 and ISO 27001, explore the framework, and learn how to build on it to assess node operators.</div>
-                  <a href="https://lidofinance.github.io/valos/valos-spec.html" target="_blank" class="button text-dm-mono-black button-sm mt-10 w-button">specIFICATIONS</a>
+                  <a href="https://lidofinance.github.io/valos/valos-spec.html" target="_blank" class="button text-dm-mono-black button-sm mt-10 w-button">Specifications</a>
                 </div>
                 <div class="div-block-4 width-100">
                   <h4 class="text-block bold line-height-30"><strong>Become An Approved Assessor</strong></h4>
@@ -317,7 +317,7 @@
                 <div class="div-block-4 width-100">
                   <h4 class="text-block bold line-height-30"><strong>Know The Standard</strong></h4>
                   <div class="text-block line-height-30 fs-18">Understand what is expected of node operators under ValOS, and how these expectations may help you better evaluate risks and safeguards around your stake.</div>
-                  <a href="https://lidofinance.github.io/valos/valos-spec.html" target="_blank" class="button text-dm-mono-black button-sm mt-10 w-button">specIFICATIONs</a>
+                  <a href="https://lidofinance.github.io/valos/valos-spec.html" target="_blank" class="button text-dm-mono-black button-sm mt-10 w-button">Specifications</a>
                 </div>
               </div>
               <div class="div-block-13">
@@ -380,7 +380,7 @@
               <h1 class="heading3 mw">Specification</h1>
               <div class="text-block fs-18 lh-27">The comprehensive standard for validator operations</div>
             </div>
-            <a href="https://lidofinance.github.io/valos/valos-spec.html" target="_blank" class="button text-dm-mono-black button-sm width-300 w-button">SPECificationS</a>
+            <a href="https://lidofinance.github.io/valos/valos-spec.html" target="_blank" class="button text-dm-mono-black button-sm width-300 w-button">Specifications</a>
           </div>
           <div class="div-block-7">
             <div class="div-block-8">
@@ -401,7 +401,7 @@
               <h1 class="heading3 mw">Repository</h1>
               <div class="text-block fs-18 lh-27">Platform for ValOS updates and improvements</div>
             </div>
-            <a href="https://github.com/lidofinance/valos" target="_blank" class="button text-dm-mono-black button-sm width-300 w-button">GITHUB</a>
+            <a href="https://github.com/lidofinance/valos" target="_blank" class="button text-dm-mono-black button-sm width-300 w-button">GitHub</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Tidies inconsistent shouty/random casing introduced by Webflow's WYSIWYG editor in [Webflow/index.html](Webflow/index.html).
- Normalized button labels: `Get the STANDARD` → `Get the Standard`, four `SPecIFICATIONS`/`specIFICATIONS`/`specIFICATIONs`/`SPECificationS` → `Specifications`, `Safer Validation starts here` → `Safer validation starts here`, `github`/`GITHUB` → `GitHub`.
- Copy: `industry-DRIVEN benchmark` → `industry-driven benchmark`.