### PR TITLE
fix(ci): pin Node to 24.15.0 for Puppeteer Chrome extraction

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,10 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24'
+          # Pinned: Node 24.16.0 breaks extract-zip, so @puppeteer/browsers
+          # leaves Chrome only partially extracted. 24.15.0 is the last good
+          # release. https://github.com/nodejs/node/issues/63487
+          node-version: '24.15.0'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
The deploy workflow's build step renders the spec with ReSpec, which drives the headless Chrome that puppeteer's `postinstall` downloads.

On **Node 24.16.0** an `extract-zip` regression leaves Chrome only **partially extracted** (the binary is missing) while the install still exits 0, so the build fails with `Could not find Chrome (ver. ...)`. See [nodejs/node#63487](https://github.com/nodejs/node/issues/63487).

Our `node-version: '24'` floats to the latest 24.x (currently 24.16.0), so deploys break. This pins Node to **24.15.0**, the last release before the regression. Revert to `'24'` once the Node fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)