### PR TITLE
fix: use getAttribute to avoid absolute localhost URLs in summary table

### DIFF
--- a/valos-spec.html
+++ b/valos-spec.html
@@ -2759,7 +2759,7 @@ This includes monitoring software that has privileged access.
 <a href="#req-log-performance-maintenance">🔗</a> <b id="req-log-performance-maintenance">Logs MUST provide a sufficiently detailed view of hardware and network performance to enable upgrade needs to be forecast,
 and to alert if validators are operating with excess latency</b>
 
-Tools such as [Zabbix](tool-zabbix) can also display a live feed of CPU and memory usage of each compute instance.
+Tools such as [Zabbix](https://github.com/zabbix/zabbix) can also display a live feed of CPU and memory usage of each compute instance.
 
 <div class="info">
 
@@ -3342,7 +3342,7 @@ function ControlTableSummary() {
 
     if (headingLink && headingText) {
       const link = document.createElement("a");
-      link.href = headingLink.href;
+      link.href = headingLink.getAttribute('href');
       link.textContent = headingText.textContent || "";
       groupCell.appendChild(link);
     }


### PR DESCRIPTION
## Summary

- `ControlTableSummary` built Control Group column links using `element.href` (DOM property), which resolves to the absolute `http://localhost:3000/valos-spec.html#…` URL when ReSpec renders under `--localhost`. Changed to `getAttribute('href')` to preserve the relative fragment reference.
- Fixed Zabbix markdown link: was `(tool-zabbix)` (broken anchor), now points to the correct external URL `https://github.com/zabbix/zabbix`.