### PR TITLE
fix(deploy): remove push trigger, require manual dispatch for reviewer gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,6 @@
 name: Deploy static content to Pages
 
 on:
-  push:
-    branches: [main]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Removes `push: branches: [main]` — deployments should be triggered manually via `workflow_dispatch`.