### PR TITLE
fix(ci): run prebuild checks on deploy, build artifact on PR CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,9 @@ jobs:
       - name: Install apparmor-utils
         run: sudo apt-get update && sudo apt-get install -y apparmor-utils
       - name: Build static spec
-        run: node scripts/build.mjs
+        # npm run build triggers prebuild (risk-reference validation +
+        # vendored asset checksum verification) before scripts/build.mjs.
+        run: npm run build
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Upload artifact

--- a/.github/workflows/validate-risk-refs.yml
+++ b/.github/workflows/validate-risk-refs.yml
@@ -1,4 +1,9 @@
-name: Validate Risk References
+# PR CI: runs the full production build (npm run build), which via the
+# prebuild script also performs risk-reference validation and vendored
+# asset checksum verification. This ensures PRs cannot merge while
+# breaking ReSpec rendering, vendored asset assumptions, CSP injection,
+# or the Pages output that deploy.yml publishes.
+name: Validate and Build
 
 on:
   pull_request:
@@ -14,11 +19,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24'
+          # Pinned: Node 24.16.0 breaks extract-zip, so @puppeteer/browsers
+          # leaves Chrome only partially extracted. 24.15.0 is the last good
+          # release. https://github.com/nodejs/node/issues/63487
+          node-version: '24.15.0'
+          cache: 'npm'
 
-      - name: Validate risk references
-        run: node ./scripts/validate-risk-refs.mjs
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install apparmor-utils
+        run: sudo apt-get update && sudo apt-get install -y apparmor-utils
+
+      - name: Build static spec
+        run: npm run build


### PR DESCRIPTION
Addresses review feedback on CI/deploy coverage:

1. **Deploy skipped package prebuild checks.** `deploy.yml` ran `node scripts/build.mjs` directly, bypassing the `prebuild` script (`npm run validate && npm run verify-vendor`). Production deploys therefore skipped risk-reference validation and vendor checksum verification. The workflow now runs `npm run build`.

2. **PR CI did not test the deploy artifact.** `validate-risk-refs.yml` only ran the risk-ref validator, so a PR could merge while breaking ReSpec rendering, Webflow processing, vendored asset assumptions, CSP injection, or the Pages output. The workflow now runs `npm ci` + `npm run build` (which includes the validator via `prebuild`).

Supporting changes to the PR workflow:
- Node pinned to 24.15.0 with npm cache, matching deploy – 24.16.0 breaks Puppeteer Chrome extraction (see #158)
- `apparmor-utils` installed so build.mjs's `aa-exec` wrapper works (per CONTRIBUTING.md)
- `persist-credentials: false` on checkout, matching deploy
- Job id `validate` kept so branch-protection required checks keep matching