### PR TITLE
Tighten deployed CSP: default-src, base-uri, form-action, object-src

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -101,14 +101,25 @@ while ((m = scriptRe.exec(html)) !== null) {
 log(`hashed ${hashes.length} inline script block(s) for CSP`);
 
 // 5. Build hardened CSP and swap in for the source CSP meta tag.
+//    default-src: 'self' — closes image/iframe/fetch/media loads by default
+//                (tracking pixels, foreign frames, exfiltration fetches).
 //    script-src: 'self' for ./fixup.js, hashes for inlines, no 'unsafe-inline'.
 //    style-src:  'self' + 'unsafe-inline' (audit FINDING-05 was script-only;
 //                style hashing is out of scope for this PR).
 //    worker-src: 'self' blob: (ReSpec's highlighter worker uses a Blob URL).
+//    object-src 'none': no plugin containers; base-uri 'self': no <base href>
+//    link hijacking; form-action 'none': the page has no forms, so nothing
+//    may ever submit anywhere. frame-ancestors is header-only and GitHub
+//    Pages cannot set response headers — documented limitation, low risk for
+//    a read-only document.
 const hardenedCsp =
+  `default-src 'self'; ` +
   `script-src 'self' ${hashes.join(' ')}; ` +
   `style-src 'self' 'unsafe-inline'; ` +
-  `worker-src 'self' blob:;`;
+  `worker-src 'self' blob:; ` +
+  `object-src 'none'; ` +
+  `base-uri 'self'; ` +
+  `form-action 'none';`;
 
 const cspMetaRe =
   /<meta\s+http-equiv="Content-Security-Policy"\s+content="[^"]*"\s*\/?>/;


### PR DESCRIPTION
**Timing: worth landing before publication** — purely additive protection for the published artifact; if it lands after, it simply hardens the next deploy (no scenario where it regresses anything).

## Change (12 lines, `scripts/build.mjs`)

Adds four missing directives to the deployed CSP:

```
default-src 'self';   — blocks external images/iframes/fetches injected into content
base-uri 'self';      — blocks <base href> link hijacking
form-action 'none';   — page has no forms; injected forms can't submit anywhere
object-src 'none';    — no plugin containers
```

Without these directives those load types are unrestricted — verified on the current deployment that an injected form actually submits and navigates away.

`frame-ancestors` is header-only and Pages can't set headers — documented limitation, low risk for a read-only page.

## Verification

Verified headless (violation listeners + full interaction sweep) locally and against a live Pages deployment of this branch: zero unexpected violations, zero console errors, nothing visually broken; injected `<img>`/`<form>`/`<base>` provably blocked. The page's only external references (W3C theme icon, watermarks) sit behind conditions ValOS never meets.
